### PR TITLE
super quick and dirty escaping " in place names

### DIFF
--- a/import.rb
+++ b/import.rb
@@ -79,7 +79,7 @@ class PlacesFilter < Nokogiri::XML::SAX::Document
 			if self.name.length > 0
 				if self.icon_carto.length > 0
 					s = "INSERT INTO places (osm_id, osm_type, name, latitude, longitude, pt, type, icon_carto, icon_fontawesome) VALUES ("
-					s += "#{self.osm_id}, 'node', \"#{self.name}\", #{self.latitude}, #{self.longitude}, ST_GeomFromText('POINT(#{self.longitude} #{self.latitude})'), '#{self.type}', '#{self.icon_carto}', '#{self.icon_fontawesome}'"
+          s += "#{self.osm_id}, 'node', \"#{self.name.gsub(/"/,'""')}\", #{self.latitude}, #{self.longitude}, ST_GeomFromText('POINT(#{self.longitude} #{self.latitude})'), '#{self.type}', '#{self.icon_carto}', '#{self.icon_fontawesome}'"
 					s += ");"
 					puts s
 				else


### PR DESCRIPTION
Dropped an inline call to `gsub` in the SQL output. :sweat_smile: 

Fixes #1 